### PR TITLE
Randomize cluster centroids between subquantizer training attempts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ num-traits = "0.2"
 ordered-float = "1"
 log = "0.4"
 rand = { version = "0.7", features = [ "small_rng" ] }
+rand_core = "0.5"
 rand_xorshift = "0.2"
 rayon = "1"
 

--- a/src/kmeans.rs
+++ b/src/kmeans.rs
@@ -65,6 +65,10 @@ where
             data.len_of(instance_axis),
             k
         );
+        assert!(
+            data.len() / data.len_of(instance_axis) > 0,
+            "Cannot pick centroids from zero-length instances"
+        );
 
         // Use random instances as centroids.
         let uniform = Uniform::new(0, data.len_of(instance_axis));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,3 +5,5 @@ pub mod linalg;
 pub(crate) mod ndarray_rand;
 
 pub mod pq;
+
+pub(crate) mod rng;

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,0 +1,102 @@
+use rand::{RngCore, SeedableRng};
+
+/// RNG that reseeds on clone.
+///
+/// This is a wrapper struct for RNGs implementing the `RngCore`
+/// trait.  It adds the following simple behavior: when a
+/// `ReseedOnCloneRng` is cloned, the clone is constructed using fresh
+/// entropy. This assures that the state of the clone is not related
+/// to the cloned RNG.
+///
+/// The `rand` crate provides similar behavior in the `ReseedingRng`
+/// struct. However, `ReseedingRng` requires that the RNG is
+/// `BlockRngCore`.
+pub struct ReseedOnCloneRng<R>(pub R)
+where
+    R: RngCore + SeedableRng;
+
+impl<R> RngCore for ReseedOnCloneRng<R>
+where
+    R: RngCore + SeedableRng,
+{
+    #[inline]
+    fn next_u32(&mut self) -> u32 {
+        self.0.next_u32()
+    }
+
+    #[inline]
+    fn next_u64(&mut self) -> u64 {
+        self.0.next_u64()
+    }
+
+    #[inline]
+    fn fill_bytes(&mut self, dest: &mut [u8]) {
+        self.0.fill_bytes(dest)
+    }
+
+    #[inline]
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+        self.0.try_fill_bytes(dest)
+    }
+}
+
+impl<R> Clone for ReseedOnCloneRng<R>
+where
+    R: RngCore + SeedableRng,
+{
+    fn clone(&self) -> Self {
+        ReseedOnCloneRng(R::from_entropy())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use rand::SeedableRng;
+    use rand_core::{self, impls, le, RngCore};
+
+    use super::ReseedOnCloneRng;
+
+    #[derive(Clone)]
+    struct BogusRng(pub u64);
+
+    impl RngCore for BogusRng {
+        fn next_u32(&mut self) -> u32 {
+            self.next_u64() as u32
+        }
+
+        fn next_u64(&mut self) -> u64 {
+            self.0 += 1;
+            self.0
+        }
+
+        fn fill_bytes(&mut self, dest: &mut [u8]) {
+            impls::fill_bytes_via_next(self, dest)
+        }
+
+        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+            Ok(self.fill_bytes(dest))
+        }
+    }
+
+    impl SeedableRng for BogusRng {
+        type Seed = [u8; 8];
+
+        fn from_seed(seed: Self::Seed) -> Self {
+            let mut state = [0u64; 1];
+            le::read_u64_into(&seed, &mut state);
+            BogusRng(state[0])
+        }
+    }
+
+    #[test]
+    fn reseed_on_clone_rng() {
+        let bogus_rng = BogusRng::from_entropy();
+        let bogus_rng_clone = bogus_rng.clone();
+        assert_eq!(bogus_rng.0, bogus_rng_clone.0);
+
+        let reseed = ReseedOnCloneRng(bogus_rng);
+        let reseed_clone = reseed.clone();
+        // One in 2^64 probability of collision given good entropy source.
+        assert_ne!((reseed.0).0, (reseed_clone.0).0);
+    }
+}


### PR DESCRIPTION
Cluster centroids are not randomized between multiple clustering
attempts -- each attempt started with the same set of centroids. This
bug was most likely introduced when switching to Rayon for parallel
quantization.

This change addresses this problem in the following manner:

- train_subquantizer() picks a new set of random centroids for each
  subquantizer training attempt;
- train_subquantizer() requires an RNG now and is called from
  the different threads created in train_pq_using(). To avoid using
  a synchronized RNG, each subquantizer gets its own RNG;
- to avoid that every subquantizer is trained from the same RNG
  state, we introduce and use the ReseedOnCloneRng type to ensure
  that each subquantizer is trained from a fresh RNG state.

Fixes #2.

---

This is a tricky bug with a somewhat non-trivial solution. I might try to write a unit test for this as well, I think this can be tested by quantizing first using one attempt and then multiple attempts. Then quantizing with multiple attempts should lead to a lower loss. The problem however is that since we need to reseed the RNGs from entropy, the test may not always succeed (since the single attempt may be the best attempt).