### PR TITLE
Add quantize_batch_into and reconstruct_batch_into methods

### DIFF
--- a/src/pq/mod.rs
+++ b/src/pq/mod.rs
@@ -10,6 +10,8 @@ mod opq;
 #[cfg(feature = "opq-train")]
 pub use self::opq::OPQ;
 
+pub(crate) mod primitives;
+
 #[allow(clippy::module_inception)]
 mod pq;
 pub use self::pq::PQ;

--- a/src/pq/opq.rs
+++ b/src/pq/opq.rs
@@ -22,7 +22,7 @@ use rayon::prelude::*;
 use crate::kmeans::KMeansIteration;
 use crate::linalg::Covariance;
 
-use super::pq::{quantize_batch, reconstruct_batch_into};
+use super::primitives;
 use super::{TrainPQ, PQ};
 
 /// Optimized product quantizer (Ge et al., 2013).
@@ -181,10 +181,9 @@ impl OPQ {
 
         // Do a quantization -> reconstruction roundtrip. We recycle the
         // projection matrix to avoid (re)allocations.
-        let quantized =
-            quantize_batch::<_, usize, _>(centroids.view(), instances.cols(), rx.view());
+        let quantized = primitives::quantize_batch::<_, usize, _>(centroids.view(), rx.view());
         let mut reconstructed = rx;
-        reconstruct_batch_into(centroids.view(), quantized, reconstructed.view_mut());
+        primitives::reconstruct_batch_into(centroids.view(), quantized, reconstructed.view_mut());
 
         // Find the new projection matrix using the instances and their
         // (projected) reconstructions. See (the text below) Eq 7 in

--- a/src/pq/primitives.rs
+++ b/src/pq/primitives.rs
@@ -1,0 +1,151 @@
+use std::iter::Sum;
+
+#[cfg(feature = "opq-train")]
+use ndarray::Array2;
+use ndarray::{
+    azip, s, Array1, ArrayBase, ArrayView3, ArrayViewMut2, Axis, Data, Ix1, Ix2, NdFloat,
+};
+
+use num_traits::{AsPrimitive, Bounded, Zero};
+
+use crate::kmeans::{cluster_assignment, cluster_assignments};
+
+pub fn quantize<A, I, S>(
+    quantizers: ArrayView3<A>,
+    quantizer_len: usize,
+    x: ArrayBase<S, Ix1>,
+) -> Array1<I>
+where
+    A: NdFloat + Sum,
+    I: 'static + AsPrimitive<usize> + Bounded + Copy + Zero,
+    S: Data<Elem = A>,
+    usize: AsPrimitive<I>,
+{
+    assert_eq!(
+        quantizer_len,
+        x.len(),
+        "Quantizer and vector length mismatch"
+    );
+
+    assert!(
+        quantizers.len_of(Axis(1)) - 1 <= I::max_value().as_(),
+        "Cannot store centroids in quantizer index type"
+    );
+
+    let mut indices = Array1::zeros(quantizers.len_of(Axis(0)));
+
+    let mut offset = 0;
+    for (quantizer, index) in quantizers.outer_iter().zip(indices.iter_mut()) {
+        // ndarray#474
+        #[allow(clippy::deref_addrof)]
+        let sub_vec = x.slice(s![offset..offset + quantizer.cols()]);
+        *index = cluster_assignment(quantizer.view(), sub_vec).as_();
+
+        offset += quantizer.cols();
+    }
+
+    indices
+}
+
+#[cfg(feature = "opq-train")]
+pub fn quantize_batch<A, I, S>(quantizers: ArrayView3<A>, x: ArrayBase<S, Ix2>) -> Array2<I>
+where
+    A: NdFloat + Sum,
+    I: 'static + AsPrimitive<usize> + Bounded + Copy + Zero,
+    S: Data<Elem = A>,
+    usize: AsPrimitive<I>,
+{
+    let mut quantized = Array2::zeros((x.rows(), quantizers.len_of(Axis(0))));
+    quantize_batch_into(quantizers, x, quantized.view_mut());
+    quantized
+}
+
+pub fn quantize_batch_into<A, I, S>(
+    quantizers: ArrayView3<A>,
+    x: ArrayBase<S, Ix2>,
+    mut quantized: ArrayViewMut2<I>,
+) where
+    A: NdFloat + Sum,
+    I: 'static + AsPrimitive<usize> + Bounded + Copy + Zero,
+    S: Data<Elem = A>,
+    usize: AsPrimitive<I>,
+{
+    assert_eq!(
+        reconstructed_len(quantizers.view()),
+        x.cols(),
+        "Quantizer and vector length mismatch"
+    );
+
+    assert!(
+        quantized.rows() == x.rows() && quantized.cols() == quantizers.len_of(Axis(0)),
+        "Quantized matrix has incorrect shape, expected: ({}, {}), got: ({}, {})",
+        x.rows(),
+        quantizers.len_of(Axis(0)),
+        quantized.rows(),
+        quantized.cols()
+    );
+
+    let mut offset = 0;
+    for (quantizer, mut quantized) in quantizers
+        .outer_iter()
+        .zip(quantized.axis_iter_mut(Axis(1)))
+    {
+        // ndarray#474
+        #[allow(clippy::deref_addrof)]
+        let sub_matrix = x.slice(s![.., offset..offset + quantizer.cols()]);
+        let assignments = cluster_assignments(quantizer.view(), sub_matrix, Axis(0));
+        azip!(mut quantized, assignments in { *quantized = assignments.as_() });
+
+        offset += quantizer.cols();
+    }
+}
+
+pub fn reconstructed_len<A>(quantizers: ArrayView3<A>) -> usize {
+    quantizers.len_of(Axis(0)) * quantizers.len_of(Axis(2))
+}
+
+pub fn reconstruct<A, I, S>(quantizers: ArrayView3<A>, quantized: ArrayBase<S, Ix1>) -> Array1<A>
+where
+    A: NdFloat,
+    I: AsPrimitive<usize>,
+    S: Data<Elem = I>,
+{
+    assert_eq!(
+        quantizers.len_of(Axis(0)),
+        quantized.len(),
+        "Quantization length does not match number of subquantizers"
+    );
+
+    let mut reconstruct = Vec::with_capacity(reconstructed_len(quantizers.view()));
+    for (&centroid, quantizer) in quantized.into_iter().zip(quantizers.outer_iter()) {
+        reconstruct.extend(quantizer.index_axis(Axis(0), centroid.as_()));
+    }
+
+    Array1::from_vec(reconstruct)
+}
+
+pub fn reconstruct_batch_into<A, I, S>(
+    quantizers: ArrayView3<A>,
+    quantized: ArrayBase<S, Ix2>,
+    mut reconstructions: ArrayViewMut2<A>,
+) where
+    A: NdFloat,
+    I: AsPrimitive<usize>,
+    S: Data<Elem = I>,
+{
+    assert!(
+        reconstructions.rows() == quantized.rows()
+            && reconstructions.cols() == reconstructed_len(quantizers.view()),
+        "Reconstructions matrix has incorrect shape, expected: ({}, {}), got: ({}, {})",
+        quantized.rows(),
+        reconstructed_len(quantizers.view()),
+        reconstructions.rows(),
+        reconstructions.cols()
+    );
+
+    for (quantized, mut reconstruction) in
+        quantized.outer_iter().zip(reconstructions.outer_iter_mut())
+    {
+        reconstruction.assign(&reconstruct(quantizers, quantized));
+    }
+}

--- a/src/pq/traits.rs
+++ b/src/pq/traits.rs
@@ -1,4 +1,4 @@
-use ndarray::{Array1, Array2, ArrayBase, Data, Ix1, Ix2};
+use ndarray::{Array1, Array2, ArrayBase, ArrayViewMut2, Data, Ix1, Ix2};
 use num_traits::{AsPrimitive, Bounded, Zero};
 use rand::{RngCore, SeedableRng};
 use rand_xorshift::XorShiftRng;
@@ -69,6 +69,13 @@ pub trait QuantizeVector<A> {
         S: Data<Elem = A>,
         usize: AsPrimitive<I>;
 
+    /// Quantize a batch of vectors into an existing matrix.
+    fn quantize_batch_into<I, S>(&self, x: ArrayBase<S, Ix2>, quantized: ArrayViewMut2<I>)
+    where
+        I: AsPrimitive<usize> + Bounded + Zero,
+        S: Data<Elem = A>,
+        usize: AsPrimitive<I>;
+
     /// Quantize a vector.
     fn quantize_vector<I, S>(&self, x: ArrayBase<S, Ix1>) -> Array1<I>
     where
@@ -82,11 +89,22 @@ pub trait QuantizeVector<A> {
 
 /// Vector reconstruction.
 pub trait ReconstructVector<A> {
-    /// Reconstruct a vector.
+    /// Reconstruct a batch of vectors.
     ///
     /// The vectors are reconstructed from the quantization indices.
     fn reconstruct_batch<I, S>(&self, quantized: ArrayBase<S, Ix2>) -> Array2<A>
     where
+        I: AsPrimitive<usize>,
+        S: Data<Elem = I>;
+
+    /// Reconstruct a batch of vectors into an existing matrix.
+    ///
+    /// The vectors are reconstructed from the quantization indices.
+    fn reconstruct_batch_into<I, S>(
+        &self,
+        quantized: ArrayBase<S, Ix2>,
+        reconstructions: ArrayViewMut2<A>,
+    ) where
         I: AsPrimitive<usize>,
         S: Data<Elem = I>;
 


### PR DESCRIPTION
These can be handy to avoid memory allocations. The following related
changes were made:

- Reimplement quantize_batch/reconstruct_batch using their batch_into
  variants.
- Move quantization/reconstruction primitives to a new primitives
  module.