### PR TITLE
Rename type and trait to comply with naming guidelines

### DIFF
--- a/benches/pq.rs
+++ b/benches/pq.rs
@@ -7,12 +7,12 @@ use rand_distr::Normal;
 use test::Bencher;
 
 use reductive::ndarray_rand::RandomExt;
-use reductive::pq::{QuantizeVector, TrainPQ, PQ};
+use reductive::pq::{QuantizeVector, TrainPq, Pq};
 
 #[bench]
 fn pq_quantize(bencher: &mut Bencher) {
     let data: Array2<f64> = Array2::random((100, 128), Normal::new(0., 1.).unwrap());
-    let pq = PQ::train_pq(16, 4, 10, 1, data.view()).unwrap();
+    let pq = Pq::train_pq(16, 4, 10, 1, data.view()).unwrap();
 
     bencher.iter(|| {
         for v in data.outer_iter() {
@@ -24,7 +24,7 @@ fn pq_quantize(bencher: &mut Bencher) {
 #[bench]
 fn pq_quantize_batch(bencher: &mut Bencher) {
     let data: Array2<f64> = Array2::random((100, 128), Normal::new(0., 1.).unwrap());
-    let pq = PQ::train_pq(16, 4, 10, 1, data.view()).unwrap();
+    let pq = Pq::train_pq(16, 4, 10, 1, data.view()).unwrap();
 
     bencher.iter(|| {
         let _: Array2<u8> = pq.quantize_batch(data.view());

--- a/src/pq/mod.rs
+++ b/src/pq/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod primitives;
 
 #[allow(clippy::module_inception)]
 mod pq;
-pub use self::pq::PQ;
+pub use self::pq::Pq;
 
 mod traits;
-pub use self::traits::{QuantizeVector, ReconstructVector, TrainPQ};
+pub use self::traits::{QuantizeVector, ReconstructVector, TrainPq};

--- a/src/pq/opq.rs
+++ b/src/pq/opq.rs
@@ -18,7 +18,7 @@ use crate::kmeans::KMeansIteration;
 use crate::linalg::Covariance;
 
 use super::primitives;
-use super::{TrainPQ, PQ};
+use super::{Pq, TrainPq};
 
 /// Optimized product quantizer (Ge et al., 2013).
 ///
@@ -37,7 +37,7 @@ use super::{TrainPQ, PQ};
 /// no effect.
 pub struct OPQ;
 
-impl<A> TrainPQ<A> for OPQ
+impl<A> TrainPq<A> for OPQ
 where
     A: Lapack + NdFloat + Scalar + Sum,
     A::Real: NdFloat,
@@ -50,12 +50,12 @@ where
         _n_attempts: usize,
         instances: ArrayBase<S, Ix2>,
         mut rng: &mut R,
-    ) -> Result<PQ<A>, rand::Error>
+    ) -> Result<Pq<A>, rand::Error>
     where
         S: Sync + Data<Elem = A>,
         R: RngCore,
     {
-        PQ::check_quantizer_invariants(
+        Pq::check_quantizer_invariants(
             n_subquantizers,
             n_subquantizer_bits,
             n_iterations,
@@ -92,7 +92,7 @@ where
             );
         }
 
-        Ok(PQ {
+        Ok(Pq {
             projection: Some(projection),
             quantizers,
         })
@@ -147,7 +147,7 @@ impl OPQ {
     {
         (0..n_subquantizers)
             .map(|sq| {
-                PQ::subquantizer_initial_centroids(
+                Pq::subquantizer_initial_centroids(
                     sq,
                     n_subquantizers,
                     codebook_len,
@@ -282,12 +282,12 @@ mod tests {
     use super::OPQ;
     use crate::linalg::EuclideanDistance;
     use crate::ndarray_rand::RandomExt;
-    use crate::pq::{QuantizeVector, ReconstructVector, TrainPQ, PQ};
+    use crate::pq::{Pq, QuantizeVector, ReconstructVector, TrainPq};
 
     /// Calculate the average euclidean distances between the the given
     /// instances and the instances returned by quantizing and then
     /// reconstructing the instances.
-    fn avg_euclidean_loss(instances: ArrayView2<f32>, quantizer: &PQ<f32>) -> f32 {
+    fn avg_euclidean_loss(instances: ArrayView2<f32>, quantizer: &Pq<f32>) -> f32 {
         let mut euclidean_loss = 0f32;
 
         let quantized: Array2<u8> = quantizer.quantize_batch(instances);

--- a/src/pq/traits.rs
+++ b/src/pq/traits.rs
@@ -3,13 +3,13 @@ use num_traits::{AsPrimitive, Bounded, Zero};
 use rand::{CryptoRng, RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 
-use crate::pq::PQ;
+use crate::pq::Pq;
 
 /// Training triat for product quantizers.
 ///
 /// This traits specifies the training functions for product
 /// quantizers.
-pub trait TrainPQ<A> {
+pub trait TrainPq<A> {
     /// Train a product quantizer with the xorshift PRNG.
     ///
     /// Train a product quantizer with `n_subquantizers` subquantizers
@@ -23,7 +23,7 @@ pub trait TrainPQ<A> {
         n_iterations: usize,
         n_attempts: usize,
         instances: ArrayBase<S, Ix2>,
-    ) -> Result<PQ<A>, rand::Error>
+    ) -> Result<Pq<A>, rand::Error>
     where
         S: Sync + Data<Elem = A>,
     {
@@ -56,7 +56,7 @@ pub trait TrainPQ<A> {
         n_attempts: usize,
         instances: ArrayBase<S, Ix2>,
         rng: &mut R,
-    ) -> Result<PQ<A>, rand::Error>
+    ) -> Result<Pq<A>, rand::Error>
     where
         S: Sync + Data<Elem = A>,
         R: CryptoRng + RngCore + SeedableRng + Send;


### PR DESCRIPTION
Suppose this is not so controversial? Thought I might help out by fixing this.