### PR TITLE
Make reconstruction faster by avoiding allocation of temporaries

### DIFF
--- a/src/pq/pq.rs
+++ b/src/pq/pq.rs
@@ -295,16 +295,6 @@ impl<A> ReconstructVector<A> for Pq<A>
 where
     A: NdFloat + Sum,
 {
-    fn reconstruct_batch<I, S>(&self, quantized: ArrayBase<S, Ix2>) -> Array2<A>
-    where
-        I: AsPrimitive<usize>,
-        S: Data<Elem = I>,
-    {
-        let mut reconstructions = Array2::zeros((quantized.nrows(), self.reconstructed_len()));
-        self.reconstruct_batch_into(quantized, reconstructions.view_mut());
-        reconstructions
-    }
-
     fn reconstruct_batch_into<I, S>(
         &self,
         quantized: ArrayBase<S, Ix2>,
@@ -323,16 +313,6 @@ where
             let projected_reconstruction = reconstructions.dot(&projection.t());
             reconstructions.assign(&projected_reconstruction);
         }
-    }
-
-    fn reconstruct_vector<I, S>(&self, quantized: ArrayBase<S, Ix1>) -> Array1<A>
-    where
-        I: AsPrimitive<usize>,
-        S: Data<Elem = I>,
-    {
-        let mut reconstruction = Array1::zeros((self.reconstructed_len(),));
-        self.reconstruct_vector_into(quantized, reconstruction.view_mut());
-        reconstruction
     }
 
     fn reconstruct_vector_into<I, S>(

--- a/src/pq/primitives.rs
+++ b/src/pq/primitives.rs
@@ -107,21 +107,6 @@ pub fn reconstructed_len<A>(quantizers: ArrayView3<A>) -> usize {
     quantizers.len_of(Axis(0)) * quantizers.len_of(Axis(2))
 }
 
-pub fn reconstruct<A, I, S>(quantizers: ArrayView3<A>, quantized: ArrayBase<S, Ix1>) -> Array1<A>
-where
-    A: NdFloat,
-    I: AsPrimitive<usize>,
-    S: Data<Elem = I>,
-{
-    let quantized_len = quantizers.len_of(Axis(0));
-    let quantizer_len = quantizers.len_of(Axis(2));
-    let reconstructed_len = quantized_len * quantizer_len;
-
-    let mut reconstruction = Array1::zeros((reconstructed_len,));
-    reconstruct_into(quantizers, quantized, reconstruction.view_mut());
-    reconstruction
-}
-
 pub fn reconstruct_into<A, I, S>(
     quantizers: ArrayView3<A>,
     quantized: ArrayBase<S, Ix1>,

--- a/src/pq/traits.rs
+++ b/src/pq/traits.rs
@@ -1,4 +1,4 @@
-use ndarray::{Array1, Array2, ArrayBase, ArrayViewMut2, Data, Ix1, Ix2};
+use ndarray::{Array1, Array2, ArrayBase, ArrayViewMut1, ArrayViewMut2, Data, Ix1, Ix2};
 use num_traits::{AsPrimitive, Bounded, Zero};
 use rand::{CryptoRng, RngCore, SeedableRng};
 use rand_chacha::ChaCha8Rng;
@@ -110,11 +110,22 @@ pub trait ReconstructVector<A> {
         I: AsPrimitive<usize>,
         S: Data<Elem = I>;
 
-    /// Reconstruct a batch of vectors.
+    /// Reconstruct a vectors.
     ///
     /// The vector is reconstructed from the quantization indices.
     fn reconstruct_vector<I, S>(&self, quantized: ArrayBase<S, Ix1>) -> Array1<A>
     where
+        I: AsPrimitive<usize>,
+        S: Data<Elem = I>;
+
+    /// Reconstruct a vector into an existing vector.
+    ///
+    /// The vector is reconstructed from the quantization indices.
+    fn reconstruct_vector_into<I, S>(
+        &self,
+        quantized: ArrayBase<S, Ix1>,
+        reconstruction: ArrayViewMut1<A>,
+    ) where
         I: AsPrimitive<usize>,
         S: Data<Elem = I>;
 


### PR DESCRIPTION
In benchmarks, this makes batch reconstruction of (non-o)pq up to ~3 faster.