### PR TITLE
Support negative eigenvalues >= -epsilon in bucketing

### DIFF
--- a/src/pq/opq.rs
+++ b/src/pq/opq.rs
@@ -236,7 +236,7 @@ where
     // ok for our purposes, since we only eigendecompose covariance
     // matrices.
     assert!(
-        eigenvalues[eigenvalue_indices[0]] >= A::zero(),
+        eigenvalues[eigenvalue_indices[0]] >= -A::epsilon(),
         "Bucketing is only supported for positive eigenvalues."
     );
 


### PR DESCRIPTION
Sometimes eigenvalue decomposition results in small negative eigenvalues. We
already add Float::epsilon during bucketing to account for this. However, we
asserted that all eigenvalues should be >= 0. This change loosens that
condition to accept >= -epsilon.