### PR TITLE
OPQ -> Opq, GaussianOPQ -> GaussianOpq

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ## Training of optimized product quantizers
 
 Training of *optimized* product quantizers requires a LAPACK implementation. For
-this reason, training of the `OPQ` and `GaussianOPQ` quantizers is feature-gated
+this reason, training of the `Opq` and `GaussianOpq` quantizers is feature-gated
 by the `opq-train` feature.  This feature must be enabled if you want to use
-`OPQ` or `GaussianOPQ`:
+`Opq` or `GaussianOpq`:
 
 ~~~toml
 [dependencies]

--- a/src/pq/gaussian_opq.rs
+++ b/src/pq/gaussian_opq.rs
@@ -6,7 +6,7 @@ use ndarray_linalg::types::Scalar;
 use num_traits::AsPrimitive;
 use rand::{CryptoRng, RngCore, SeedableRng};
 
-use super::{Pq, TrainPq, OPQ};
+use super::{Opq, Pq, TrainPq};
 
 /// Optimized product quantizer for Gaussian variables (Ge et al., 2013).
 ///
@@ -18,12 +18,12 @@ use super::{Pq, TrainPq, OPQ};
 /// This quantizer learns a orthonormal matrix that rotates the input
 /// space in order to balance variances over subquantizers. The
 /// optimization procedure assumes that the variables have a Gaussian
-/// distribution. The `OPQ` quantizer provides a non-parametric,
+/// distribution. The `Opq` quantizer provides a non-parametric,
 /// albeit slower to train implementation of optimized product
 /// quantization.
-pub struct GaussianOPQ;
+pub struct GaussianOpq;
 
-impl<A> TrainPq<A> for GaussianOPQ
+impl<A> TrainPq<A> for GaussianOpq
 where
     A: Lapack + NdFloat + Scalar + Sum,
     A::Real: NdFloat,
@@ -49,7 +49,7 @@ where
             instances.view(),
         );
 
-        let projection = OPQ::create_projection_matrix(instances.view(), n_subquantizers);
+        let projection = Opq::create_projection_matrix(instances.view(), n_subquantizers);
         let rx = instances.dot(&projection);
         let pq = Pq::train_pq_using(
             n_subquantizers,
@@ -74,7 +74,7 @@ mod tests {
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
 
-    use super::GaussianOPQ;
+    use super::GaussianOpq;
     use crate::linalg::EuclideanDistance;
     use crate::ndarray_rand::RandomExt;
     use crate::pq::{Pq, QuantizeVector, Reconstruct, TrainPq};
@@ -100,7 +100,7 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         let uniform = Uniform::new(0f32, 1f32);
         let instances = Array2::random_using((256, 20), uniform, &mut rng);
-        let pq = GaussianOPQ::train_pq_using(10, 7, 10, 1, instances.view(), &mut rng).unwrap();
+        let pq = GaussianOpq::train_pq_using(10, 7, 10, 1, instances.view(), &mut rng).unwrap();
         let loss = avg_euclidean_loss(instances.view(), &pq);
         // Loss is around 0.1.
         assert!(loss < 0.12);

--- a/src/pq/mod.rs
+++ b/src/pq/mod.rs
@@ -3,12 +3,12 @@
 #[cfg(feature = "opq-train")]
 mod gaussian_opq;
 #[cfg(feature = "opq-train")]
-pub use gaussian_opq::GaussianOPQ;
+pub use gaussian_opq::GaussianOpq;
 
 #[cfg(feature = "opq-train")]
 mod opq;
 #[cfg(feature = "opq-train")]
-pub use self::opq::OPQ;
+pub use self::opq::Opq;
 
 pub(crate) mod primitives;
 

--- a/src/pq/opq.rs
+++ b/src/pq/opq.rs
@@ -29,15 +29,15 @@ use super::{Pq, TrainPq};
 ///
 /// This quantizer learns a orthonormal matrix that rotates the input
 /// space in order to balance variances over subquantizers. If the
-/// variables have a Gaussian distribution, `GaussianOPQ` is faster to
+/// variables have a Gaussian distribution, `GaussianOpq` is faster to
 /// train than this quantizer.
 ///
 /// This quantizer always trains the quantizer in one attempt, so the
 /// `n_attempts` argument of the `TrainPQ` constructors currently has
 /// no effect.
-pub struct OPQ;
+pub struct Opq;
 
-impl<A> TrainPq<A> for OPQ
+impl<A> TrainPq<A> for Opq
 where
     A: Lapack + NdFloat + Scalar + Sum,
     A::Real: NdFloat,
@@ -99,7 +99,7 @@ where
     }
 }
 
-impl OPQ {
+impl Opq {
     pub(crate) fn create_projection_matrix<A>(
         instances: ArrayView2<A>,
         n_subquantizers: usize,
@@ -279,7 +279,7 @@ mod tests {
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
 
-    use super::OPQ;
+    use super::Opq;
     use crate::linalg::EuclideanDistance;
     use crate::ndarray_rand::RandomExt;
     use crate::pq::{Pq, QuantizeVector, Reconstruct, TrainPq};
@@ -332,7 +332,7 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         let uniform = Uniform::new(0f32, 1f32);
         let instances = Array2::random_using((256, 20), uniform, &mut rng);
-        let pq = OPQ::train_pq_using(10, 7, 10, 1, instances.view(), &mut rng).unwrap();
+        let pq = Opq::train_pq_using(10, 7, 10, 1, instances.view(), &mut rng).unwrap();
         let loss = avg_euclidean_loss(instances.view(), &pq);
         // Loss is around 0.09.
         assert!(loss < 0.1);


### PR DESCRIPTION
Rename types to conform to Rust naming conventions.